### PR TITLE
add dotenv file support

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,2 @@
+# FRAMSTICKS_DLL_PATH=./Framsticks52
+# FRAMSPY_PATH=./framspy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ dependencies = [
     "framspy-local-package",
     "numpy>=2.2.6",
     "ipykernel>=6.29.5",
-    "scipy>=1.15.3"
+    "scipy>=1.15.3",
+    "python-dotenv>=1.1.0",
 ]
 
 [tool.uv.sources]

--- a/run_gomea_f1.py
+++ b/run_gomea_f1.py
@@ -1,17 +1,27 @@
 import argparse
+import os
 import random
 from functools import partial
 from pathlib import Path
 
 import numpy as np
 from deap import base, creator, gp, tools
+from dotenv import load_dotenv
 
+import framspy
 from framspy.src.FramsticksLibCompetition import FramsticksLibCompetition
 from src.gomea import eaGOMEA, forced_improvement, gom, override_nodes
 from src.gpf1 import create_f1_pset, parse
 from src.linkage import LinkageTreeFramsF1
 from src.utils.fpcontrol import print_fenv_state, restore_fenv
 from src.utils.stopping import EarlyStopper, earlyStoppingOrMaxIter
+
+
+load_dotenv()
+# default values for --framslib and --sim_location
+ENV_FRAMSTICKS_DLL = os.getenv("FRAMSTICKS_DLL_PATH", "./Framsticks52")
+# ENV_FRAMSPY_PATH = os.getenv("FRAMSPY_PATH", "./framspy")
+ENV_FRAMSPY_PATH = os.getenv("FRAMSPY_PATH", str(framspy.__path__[0]))
 
 
 def prepare_gomea_parser(parser):
@@ -25,9 +35,19 @@ def prepare_gomea_parser(parser):
                         default=['eval-allcriteria.sim', 'recording-body-coords.sim'],
                         help='List of simulation files to use.')
     parser.add_argument('--no_forced_improv', action='store_true')
-    parser.add_argument('--sim_location', help="Specifies location of simfiles.", default="./framspy")
-    parser.add_argument('--framslib', help="Specifies location of framstick engine.", default="./Framsticks52")
-    parser.add_argument('--pmut', help="Probability of mutation occuring", default=0.8, type=float)
+    parser.add_argument(
+        "--sim_location",
+        help="Specifies location of simfiles.",
+        default=ENV_FRAMSPY_PATH,
+        #  default="./framspy"
+    )
+    parser.add_argument(
+        "--framslib",
+        help="Specifies location of framstick engine.",
+        default=ENV_FRAMSTICKS_DLL,
+        #  default="./Framsticks52"
+    )
+    parser.add_argument("--pmut", help="Probability of mutation occuring", default=0.8, type=float)
     parser.add_argument('--fmut', help="Frequency of mutation occuring", default=10, type=int)
     parser.add_argument('--count_nevals', help="Counts evaluations of genotype", action="store_true")
 

--- a/run_gomea_f1.py
+++ b/run_gomea_f1.py
@@ -1,4 +1,5 @@
 import argparse
+import random
 from functools import partial
 from pathlib import Path
 
@@ -9,9 +10,8 @@ from framspy.src.FramsticksLibCompetition import FramsticksLibCompetition
 from src.gomea import eaGOMEA, forced_improvement, gom, override_nodes
 from src.gpf1 import create_f1_pset, parse
 from src.linkage import LinkageTreeFramsF1
-from src.utils.fpcontrol import *
+from src.utils.fpcontrol import print_fenv_state, restore_fenv
 from src.utils.stopping import EarlyStopper, earlyStoppingOrMaxIter
-
 
 
 def prepare_gomea_parser(parser):
@@ -37,7 +37,6 @@ def prepare_gomea_parser(parser):
 #toolbox = LinkageToolbox('build_linkage_model', 'override_nodes')
 #toolbox.define_default_linkages(CHARS, PREFIX, original_control_word)
 
-import random
 
 def evaluate(ptree, pset, flib, invalid_fitness, criteria):
     try:
@@ -74,13 +73,15 @@ def generate_random(flib, n=100, geno_format="1"):
 
 
 def create_ind(flib, pset, n=100):
-    return parse(generate_random(flib, n)[0].replace(" ",""), pset)
+    return parse(generate_random(flib, n)[0].replace(" ", ""), pset)
 
-def create_subtree(flib, pset, low=0,high=100,type_=None):
-    n = np.random.randint(low,high)
-    return parse(generate_random(flib, n)[0].replace(" ",""), pset)
 
-if __name__ == '__main__':
+def create_subtree(flib, pset, low=0, high=100, type_=None):
+    n = np.random.randint(low, high)
+    return parse(generate_random(flib, n)[0].replace(" ", ""), pset)
+
+
+def main():
     # prepare arguments
     parser = argparse.ArgumentParser(
                     prog='GOMEA experiment',
@@ -187,3 +188,7 @@ if __name__ == '__main__':
     # saving outputs
     #######################
     framsLib.end()
+
+
+if __name__ == "__main__":
+    main()

--- a/run_gomea_f1.py
+++ b/run_gomea_f1.py
@@ -41,11 +41,11 @@ def prepare_gomea_parser(parser):
 def evaluate(ptree, pset, flib, invalid_fitness, criteria):
     try:
         geno = [str(gp.compile(ptree, pset))]
-    except:
+    except Exception:
         return (invalid_fitness,)
     try:
         valid = flib.isValidCreature(geno)[0]
-    except:
+    except Exception:
         print(geno)
         raise Exception
     if not valid:

--- a/src/stats.py
+++ b/src/stats.py
@@ -1,9 +1,9 @@
-import numpy as np
-from scipy.stats import spearmanr, pearsonr, entropy
-
 from collections import Counter
 
-from src.utils.fpcontrol import *
+import numpy as np
+from scipy.stats import entropy, pearsonr, spearmanr
+
+from src.utils.fpcontrol import print_fenv_state, restore_fenv
 
 
 def correlation(population, char_order, cor_func, original_control_word=None):

--- a/uv.lock
+++ b/uv.lock
@@ -137,6 +137,7 @@ dependencies = [
     { name = "framspy-local-package" },
     { name = "ipykernel" },
     { name = "numpy" },
+    { name = "python-dotenv" },
     { name = "scipy" },
 ]
 
@@ -146,6 +147,7 @@ requires-dist = [
     { name = "framspy-local-package", editable = "framspy" },
     { name = "ipykernel", specifier = ">=6.29.5" },
     { name = "numpy", specifier = ">=2.2.6" },
+    { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "scipy", specifier = ">=1.15.3" },
 ]
 
@@ -424,6 +426,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/2c/7bb1416c5620485aa793f2de31d3df393d3686aa8a8506d11e10e13c5baf/python_dotenv-1.1.0.tar.gz", hash = "sha256:41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5", size = 39920, upload-time = "2025-03-25T10:14:56.835Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/18/98a99ad95133c6a6e2005fe89faedf294a748bd5dc803008059409ac9b1e/python_dotenv-1.1.0-py3-none-any.whl", hash = "sha256:d7c01d9e2293916c18baf562d95698754b0dbbb5e74d457c45d4f6561fb9d55d", size = 20256, upload-time = "2025-03-25T10:14:55.034Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
I added python-dotenv package https://pypi.org/project/python-dotenv/ which reads environment variables from `.env` files.

Setting these will set default values for `--framslib` and `--sim_location` options.

- [x] Example `.env` file
- [x] Getting `framspy` path from imported Python module
- [ ] update README (TODO if merged)